### PR TITLE
Attempt to load libjvm.dylib using JAVA_HOME on Darwin

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -33,39 +33,54 @@ jint dyn_JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *args) {
 import "C"
 
 import (
-    "unsafe"
+	"unsafe"
+	"os"
+	"path"
 )
 
 func jni_GetDefaultJavaVMInitArgs(args unsafe.Pointer) jint {
-    return jint(C.dyn_JNI_GetDefaultJavaVMInitArgs((unsafe.Pointer)(args)))
+	return jint(C.dyn_JNI_GetDefaultJavaVMInitArgs((unsafe.Pointer)(args)))
 }
 
 func jni_CreateJavaVM(pvm unsafe.Pointer, penv unsafe.Pointer, args unsafe.Pointer) jint {
-    return jint(C.dyn_JNI_CreateJavaVM((**C.JavaVM)(pvm), (*unsafe.Pointer)(penv), (unsafe.Pointer)(args)))
+	return jint(C.dyn_JNI_CreateJavaVM((**C.JavaVM)(pvm), (*unsafe.Pointer)(penv), (unsafe.Pointer)(args)))
 }
 
-
 func init() {
-    cs := cString("/Library/Java/Home/jre/lib/server/libjvm.dylib")
-    defer free(cs)
-    libHandle := uintptr(C.dlopen((*C.char)(cs), C.RTLD_NOW | C.RTLD_GLOBAL))
-    if libHandle == 0 {
-        panic("could not dyanmically load libjvm.dylib")
-    }
+	var (
+		cs unsafe.Pointer
+	)
+	defer free(cs)
 
-    cs2 := cString("JNI_GetDefaultJavaVMInitArgs")
-    defer free(cs2)
-    ptr := C.dlsym(unsafe.Pointer(libHandle), (*C.char)(cs2))
-    if ptr == nil {
-        panic("could not find JNI_GetDefaultJavaVMInitArgs in libjvm.dylib")
-    }
-    C.var_JNI_GetDefaultJavaVMInitArgs = C.type_JNI_GetDefaultJavaVMInitArgs(ptr)
+	// First, check if JAVA_HOME is set as an environment variable.
+	// On Darwin, this usually is set to something like:
+	// /Library/Java/JavaVirtualMachines/jdkVERSION.jdk/Contents/Home
+	// Where VERSION is the Java version (i.e. 1.8.0).
+	if key, ok := os.LookupEnv("JAVA_HOME"); ok {
+		cs = cString(path.Join(key, "/jre/lib/server/libjvm.dylib"))
+	} else {
+		// In the event that JAVA_HOME is not set, we fall back to a hard-coded string.
+		cs = cString("/Library/Java/Home/jre/lib/server/libjvm.dylib")
+	}
 
-    cs3 := cString("JNI_CreateJavaVM")
-    defer free(cs3)
-    ptr = C.dlsym(unsafe.Pointer(libHandle), (*C.char)(cs3))
-    if ptr == nil {
-        panic("could not find JNI_CreateJavaVM in libjvm.dylib")
-    }
-    C.var_JNI_CreateJavaVM = C.type_JNI_CreateJavaVM(ptr)
+	libHandle := uintptr(C.dlopen((*C.char)(cs), C.RTLD_NOW|C.RTLD_GLOBAL))
+	if libHandle == 0 {
+		panic("could not dyanmically load libjvm.dylib")
+	}
+
+	cs2 := cString("JNI_GetDefaultJavaVMInitArgs")
+	defer free(cs2)
+	ptr := C.dlsym(unsafe.Pointer(libHandle), (*C.char)(cs2))
+	if ptr == nil {
+		panic("could not find JNI_GetDefaultJavaVMInitArgs in libjvm.dylib")
+	}
+	C.var_JNI_GetDefaultJavaVMInitArgs = C.type_JNI_GetDefaultJavaVMInitArgs(ptr)
+
+	cs3 := cString("JNI_CreateJavaVM")
+	defer free(cs3)
+	ptr = C.dlsym(unsafe.Pointer(libHandle), (*C.char)(cs3))
+	if ptr == nil {
+		panic("could not find JNI_CreateJavaVM in libjvm.dylib")
+	}
+	C.var_JNI_CreateJavaVM = C.type_JNI_CreateJavaVM(ptr)
 }


### PR DESCRIPTION
Hey there, I'd just like to submit this PR with the hopes of resolving #3. When loading libsvm.dylib on Darwin, I check to see if it can first be loaded using the JAVA_HOME environment variable, and then fall-back to the previous hard-coded string. 

I haven't tested it but this approach could also probably be used for linux too.