### PR TITLE
Adding GetJavaVM method

### DIFF
--- a/cwrapper.go
+++ b/cwrapper.go
@@ -575,7 +575,7 @@ jint DetachCurrentThread(JavaVM* vm) {
 }
 
 jint GetJavaVM(JNIEnv* env, JavaVM** vm) {
-	return (*env)->GetJavaVM (env, vm);	
+	return (*env)->GetJavaVM (env, vm);
 }
 */
 import "C"

--- a/cwrapper.go
+++ b/cwrapper.go
@@ -573,6 +573,10 @@ jint AttachCurrentThread(JavaVM* vm, void** penv, void* args) {
 jint DetachCurrentThread(JavaVM* vm) {
 	return (*vm)->DetachCurrentThread (vm);
 }
+
+jint GetJavaVM(JNIEnv* env, JavaVM** vm) {
+	return (*env)->GetJavaVM (env, vm);	
+}
 */
 import "C"
 
@@ -1178,3 +1182,6 @@ func detachCurrentThread(vm unsafe.Pointer) jint {
 	return jint(C.DetachCurrentThread((*C.JavaVM)(vm)))
 }
 
+func getJavaVM(env unsafe.Pointer, vm unsafe.Pointer) jint {
+	return jint(C.GetJavaVM((*C.JNIEnv)(env), (**C.JavaVM)(vm)))
+}

--- a/jnigi.go
+++ b/jnigi.go
@@ -127,7 +127,7 @@ func (j *JVM) DetachCurrentThread() error {
 
 func (j *Env) GetJavaVM() (*JVM, error) {
 	runtime.LockOSThread()
-	p := malloc(unsafe.Sizeof((unsafe.Pointer)(nil)))	
+	p := malloc(unsafe.Sizeof((unsafe.Pointer)(nil)))
 
 	if getJavaVM(j.jniEnv, p) < 0 {
 		return nil, errors.New("Couldn't get JVM")

--- a/jnigi.go
+++ b/jnigi.go
@@ -125,6 +125,21 @@ func (j *JVM) DetachCurrentThread() error {
 	return nil
 }
 
+func (j *Env) GetJavaVM() (*JVM, error) {
+	runtime.LockOSThread()
+	p := malloc(unsafe.Sizeof((unsafe.Pointer)(nil)))	
+
+	if getJavaVM(j.jniEnv, p) < 0 {
+		return nil, errors.New("Couldn't get JVM")
+	}
+
+	jvm := &JVM{*(*unsafe.Pointer)(p)}
+
+	free(p)
+
+	return jvm, nil
+}
+
 func (j *Env) exceptionCheck() bool {
 	return toBool(exceptionCheck(j.jniEnv))
 }

--- a/jnigi_test.go
+++ b/jnigi_test.go
@@ -20,6 +20,7 @@ func TestAll(t *testing.T) {
 	PTestInstanceOf(t)
 	PTestByteArray(t)
 	PTestAttach(t)
+	PTestGetJavaVM(t)
 }
 
 func PTestInit(t *testing.T) {
@@ -279,4 +280,12 @@ func PTestByteArray(t *testing.T) {
 		t.Logf("ByteArray test failed")
 	}
 	ba2.ReleaseCritical(env, bytes)
+}
+
+func PTestGetJavaVM(t *testing.T) {
+    _, err := env.GetJavaVM()
+    if err != nil {
+        t.Fatalf("GetJavaVM failed %s", err)
+    }
+	t.Logf("Call GetJavaJVM: passed")
 }


### PR DESCRIPTION
When Golang project is used as a library and there is multi-threading involved, I need to get the JavaVM from the current JNIEnv and attach it to the Java thread.

Example:

```
var env *jnigi.Env
var jvm *jnigi.JVM

func Java_mypackage_mymethod(jniEnv unsafe.Pointer, clazz uintptr) {
    env = jnigi.WrapEnv(jniEnv)
    javaVM, err := env.GetJavaVM()
    if err == nil {        
        jvm = javaVM
    }
}

//Considering this callback is getting called from a goroutine
func callback() {
    var nenv = jvm.AttachCurrentThread()
    nenv.CallStaticMethod(...)
    jvm.DetachCurrentThread()
}
```