### PR TITLE
Expanding $OSTYPE linux-gnu to include linux-gnueabihf

### DIFF
--- a/compilevars.sh
+++ b/compilevars.sh
@@ -5,7 +5,7 @@ if [[ "$jdk_path" == "" ]]; then
 	echo "usage: source ./compilevars.sh <jdk path>"
 else
 
-  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 	  osdir=linux
   elif [[ "$OSTYPE" == "darwin"* ]]; then
   	  osdir=darwin


### PR DESCRIPTION
The OS `linux-gnueabihf` also has the same folder directory. 

I am adding `*` to the end of `if [[ "$OSTYPE" == "linux-gnu"* ]]; then` so `osdir=linux` can be picked up.