### PR TITLE
Windows: make attempt to find jvm dll path better

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -18,7 +18,14 @@ func AttemptToFindJVMLibPath() string {
 			prefix = "/usr/lib/jvm/default-java"
 		}
 	}
-	dirPath := filepath.Join(prefix, "jre", "lib", runtime.GOARCH, "server")
+
+	dirPath := filepath.Join(prefix, "jre")
+	if runtime.GOOS == "windows" {
+		dirPath = filepath.Join(dirPath, "bin", "server")
+	} else {
+		dirPath = filepath.Join(dirPath, "lib", runtime.GOARCH, "server")
+	}
+
 	var libPath string
 	if runtime.GOOS == "windows" {
 		libPath = filepath.Join(dirPath, "jvm.dll")

--- a/jnigi_test.go
+++ b/jnigi_test.go
@@ -26,6 +26,7 @@ func TestAll(t *testing.T) {
 func PTestInit(t *testing.T) {
 	libPath := AttemptToFindJVMLibPath()
 	if err := LoadJVMLib(libPath); err != nil {
+		t.Logf("library path = %s", libPath)
 		t.Log("can use JAVA_HOME environment variable to set JRE root directory")
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The default sub directory in  the jdk is different on Windows Java.