### PR TITLE
Fix JNI local refs warning by deleting local ref to returned object

### DIFF
--- a/jnigi.go
+++ b/jnigi.go
@@ -1082,11 +1082,11 @@ func (o *ObjectRef) CallMethod(env *Env, methodName string, returnType interface
 		retVal = float64(callDoubleMethodA(env.jniEnv, o.jobject, mid, jniArgs))
 	case rType == Object || rType.isArray():
 		obj := callObjectMethodA(env.jniEnv, o.jobject, mid, jniArgs)
-		refs = append(refs, obj)
 		if rType == Object || rType == Object|Array || env.noReturnConvert {
 			retVal = &ObjectRef{obj, rClassName, rType.isArray()}
 		} else {
 			arrayToConvert = obj
+			refs = append(refs, obj)
 		}
 	default:
 		return nil, errors.New("JNIGI unknown return type")

--- a/jnigi.go
+++ b/jnigi.go
@@ -1082,6 +1082,7 @@ func (o *ObjectRef) CallMethod(env *Env, methodName string, returnType interface
 		retVal = float64(callDoubleMethodA(env.jniEnv, o.jobject, mid, jniArgs))
 	case rType == Object || rType.isArray():
 		obj := callObjectMethodA(env.jniEnv, o.jobject, mid, jniArgs)
+		refs = append(refs, obj)
 		if rType == Object || rType == Object|Array || env.noReturnConvert {
 			retVal = &ObjectRef{obj, rClassName, rType.isArray()}
 		} else {


### PR DESCRIPTION
I get this warning all the time
`WARNING: JNI local refs: 363, exceeds capacity: 362`
when trying to use methods that return an object
It seems that local references to the returned values are not deleted. This small fix avoids the warning, but I'm not sure it's completely correct. Please take a look at this