### PR TITLE
Fix calling methods that return void

### DIFF
--- a/jnigi.go
+++ b/jnigi.go
@@ -1059,6 +1059,8 @@ func typeOfValue(value interface{}) (t Type, className string, err error) {
 	case convertedArray:
 		t = v.getType()
 		className = "java/lang/Object"
+	case nil:
+		t = Void
 	default:
 		err = fmt.Errorf("JNIGI: unknown type %T (value = %v)", v, v)
 	}
@@ -1395,10 +1397,8 @@ func (j *Env) CallStaticMethod(className string, methodName string, dest interfa
 		}
 
 		return assignDest(converted, dest)
-	} else if rType != Void {
-		return assignDest(retVal, dest)
 	} else {
-		return nil
+		return assignDest(retVal, dest)
 	}
 }
 


### PR DESCRIPTION
As part of #56, a change was introduced that allowed support for Void types in CallStaticMethod. This was somewhat of an oversight in my commit.

https://github.com/iamcalledrob/jnigi/blob/b9076f4b244646ae7818cd22729eb631f0a7bbf4/jnigi.go#L1398-L1402
```go
if v, ok := dest.(ToGoConverter); ok && (rType&Object == Object || rType&Array == Array) {
	// ...
} else if rType.isArray() && rType != Object|Array {
	// ...
} else if rType != Void {                    // <-- Change
	return assignDest(retVal, dest)      // <--
} else {
	return nil
}
```

This addressed an issue I was experiencing where I couldn't call a method with a void dest.

When I tried passing in `jnigi.Void` as the call dest, the following error occurred:
```go
jnigi.CallStaticMethod("com/foo/bar", "myVoidMethod", jnigi.Void /* <- dest */, someArg)
// JNIGI Error: expected dest argument to be <nil>[val] (not jnigi.Type[dest]) or nil)
```

However when `nil` was passed in, this error occurred:
```go
jnigi.CallStaticMethod("com/foo/bar", "myVoidMethod", nil /* <- dest */, someArg)
// JNIGI: unknown type <nil> (value = <nil>)):
```

This led to it being impossible to make calls to void methods, at least as far as I could tell.

What appears to be happening is that if dest was set to `jnigi.Void`, the method signature would be calculated correctly, however `assignDest` would fail, since `jnigi.Void` is not a handled case.

However if the dest was set to `nil`, calculating the method signature in `sigForMethod` would fail, because `typeOfValue` does not handle `nil`. The resulting `assignDest` would have succeeded, since it does a nil check, but we never get there because of the signature calculation failure.

The fix in #56 addressed this issue in a single specific case (CallStaticMethod), but not universally.

This PR applies a fix to `typeOfValue` to map `nil` to `jnigi.Void`, so the method signature can be calculated correctly. The existing nil check in `assignDest` then works as expected. Methods that return void can now be called as follows:
```go
jnigi.CallStaticMethod("com/foo/bar", "myVoidMethod", nil /* <- dest */, someArg)
````