### PR TITLE
change include of windows.h to lower case

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -9,7 +9,7 @@ package jnigi
 
 /*
 #include <jni.h>
-#include <Windows.h>
+#include <windows.h>
 
 typedef jint (*type_JNI_GetDefaultJavaVMInitArgs)(void*);
 


### PR DESCRIPTION
per default Microsoft defaults its examples to `#include <Windows.h>`, which is fine for building in Windows (since the file system of Windows is case insensitive).

But if you want to cross build the application (e.g. via golang crossbuild - https://github.com/elastic/golang-crossbuild), the build will fail because this toolchain contains the file in lowercase `windows.h`

I tested crossbuilding with the lower include which works fine. Unfortunately I was not able to build on Windows yet