### PR TITLE
Fix: fixed memory leak problem

### DIFF
--- a/jnigi.go
+++ b/jnigi.go
@@ -223,7 +223,12 @@ func (j *JVM) AttachCurrentThread() *Env {
 }
 
 // DetachCurrentThread calls JNI DetachCurrentThread
-func (j *JVM) DetachCurrentThread() error {
+func (j *JVM) DetachCurrentThread(env *Env) error {
+	//free cache
+	for _, v := range env.classCache {
+		deleteGlobalRef(env.jniEnv, jobject(v))
+	}
+
 	if detachCurrentThread(j.javaVM) < 0 {
 		return errors.New("JNIGI: detachCurrentThread error")
 	}


### PR DESCRIPTION
Hello, when I used this project for development, I found a memory leak bug, that is, when calling AttachCurrentThread, a global cache will be created, but when DetachCurrentThread, the global reference object is not released. This problem will cause the CPU load to continue to increase when processing large-scale requests.