### PR TITLE
Feature: support deleting GlobalRef from Env.classCache to avoid memory leak

### DIFF
--- a/jnigi.go
+++ b/jnigi.go
@@ -224,10 +224,7 @@ func (j *JVM) AttachCurrentThread() *Env {
 
 // DetachCurrentThread calls JNI DetachCurrentThread, pass Env returned from AttachCurrentThread for current thread.
 func (j *JVM) DetachCurrentThread(env *Env) error {
-	//free cache
-	for _, v := range env.classCache {
-		deleteGlobalRef(env.jniEnv, jobject(v))
-	}
+	env.DeleteGlobalRefCache()
 
 	if detachCurrentThread(j.javaVM) < 0 {
 		return errors.New("JNIGI: detachCurrentThread error")
@@ -1907,6 +1904,15 @@ func (j *Env) GetUTF8String() *ObjectRef {
 	}
 
 	return utf8
+}
+
+// DeleteGlobalRefCache deletes all globalRef that are in classCache. This methods should
+// be called when an instance of *Env gets out of scope
+func (j *Env) DeleteGlobalRefCache() {
+	for _, v := range j.classCache {
+		deleteGlobalRef(j.jniEnv, jobject(v))
+	}
+	j.classCache = make(map[string]jclass)
 }
 
 // StackTraceElement is a struct holding the contents of java.lang.StackTraceElement

--- a/jnigi_test.go
+++ b/jnigi_test.go
@@ -35,6 +35,7 @@ func TestAll(t *testing.T) {
 	PTestCast(t)
 	PTestNonVirtual(t)
 	PTestRegisterNative(t)
+	PTestDeleteGlobalRefCache(t)
 	PTestDestroy(t)
 }
 
@@ -378,6 +379,7 @@ func PTestGetJVM(t *testing.T) {
 }
 
 func PTestDestroy(t *testing.T) {
+	env.DeleteGlobalRefCache()
 	err := jvm.Destroy()
 	if err != nil {
 		t.Fatalf("DestroyJVM failed %s", err)
@@ -591,6 +593,24 @@ func PTestRegisterNative(t *testing.T) {
 	}
 	goStr := toGoStr(t, strRef)
 	if !assert.Equal(t, "Hello World!", goStr) {
+		t.Fail()
+	}
+}
+
+func PTestDeleteGlobalRefCache(t *testing.T) {
+	str, err := env.NewObject("java/lang/String", []byte("hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer env.DeleteLocalRef(str)
+	var goBytes []byte
+	if err := str.CallMethod(env, "getBytes", &goBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	env.DeleteGlobalRefCache()
+
+	if !assert.Empty(t, env.classCache) {
 		t.Fail()
 	}
 }

--- a/jnigi_test_c_callback.go
+++ b/jnigi_test_c_callback.go
@@ -17,6 +17,7 @@ import "C"
 //export go_callback_Greet
 func go_callback_Greet(jenv unsafe.Pointer, jobj uintptr, arg_0 uintptr) uintptr {
 	env := WrapEnv(jenv)
+	defer env.DeleteGlobalRefCache()
 	env.ExceptionHandler = ThrowableToStringExceptionHandler
 
 	strArgRef := WrapJObject(arg_0, "java/lang/String", false)


### PR DESCRIPTION
# ✨ Types of changes
- Enhancement
- New Feature

# 💡 Motivation and Context

My application was recently experiencing OOM after running for a couple days. The architecture of the app is Java running on top, calling into JNI using `jnigi` then calling into Go. Java can make many calls to the JNI layer with different types of parameters, including `String`.

This was a very interesting/hard leak to find, because the memory stats from the Main app running in Java didn't indicate any abnormal growth, but the RSS values definitely had a very linear curve. So we started isolating the components and verified that the leak was coming from the JNI. I then wrote a stress test app and used `jemalloc` to trace the memory on the stack. `jemalloc` gave me this chart:

![leak](https://github.com/timob/jnigi/assets/309031/db48e9b9-7c83-4139-b5cf-5149269e35cf)

That showed me that there is a large % of memory used by `jni_NewGlobalRef` that wasn't getting freed. _For some reason the map symbols were not working on the memory boxes above the global ref._ I then started tracing where `jnigi` calls `jni_NewGlobalRef` and that was how I got to the problem.

# 🐛 Problem

Here is how my JNI layer looks with the leak:

```golang
//export Java_com_example_process
func Java_com_example_process(jniEnv unsafe.Pointer, clazz uintptr, jname uintptr) {
	env := jnigi.WrapEnv(jniEnv)
	strObj := jnigi.WrapJObject(jname, "java/lang/String", false)
	defer env.DeleteLocalRef(strObj)
	var goString []byte
	err := strObj.CallMethod(env, "getBytes", &goString)
	if err != nil {
		return
	}
	//Call into go with goString
}
```

That looked sort of harmless in the beginning, until we had to run the app for days. 

The issue lives inside of the `env.classCache`. When `env` gets out of scope, all of the `env.classCache` will also get destroyed. The catch is that those objects inside of `env.classCache` were created using `NewGlobalRef` by `callFindClass` and are not deleted when `env` gets out of scope, creating dangling references.

# 🎯 Solution

This PR is introducing a new method called `env.DeleteGlobalRefCache()`, this method should be called after you want to dispose an instance of `*jnigi.Env`. It'll call `deleteGlobalRef` in all of the `classCache` and clear the map as well.

```golang
//export Java_com_example_process
func Java_com_example_process(jniEnv unsafe.Pointer, clazz uintptr, jname uintptr) {
	env := jnigi.WrapEnv(jniEnv)
        defer env.DeleteGlobalRefCache()
	strObj := jnigi.WrapJObject(jname, "java/lang/String", false)
	defer env.DeleteLocalRef(strObj)
	var goString []byte
	err := strObj.CallMethod(env, "getBytes", &goString)
	if err != nil {
		return
	}
	//Call into go with goString
}
```